### PR TITLE
Add parameter to disable the managing of the SSH firewall rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Parameters:
 |-----------|---------|-------------|
 | allow_new_outgoing_ipv4 | false | Boolean parameter that determines if the firewall should allow all new outgoing IPv4 connections. The parameter defaults to false which means that new outgoing connections will be dropped unless there is a rule that explicitly allows the traffic. |
 | allow_new_outgoing_ipv6 | false | Boolean parameter that determines if the firewall should allow all new outgoing IPv6 connections. The parameter defaults to false which means that new outgoing connections will be dropped unless there is a rule that explicitly allows the traffic. |
+| manage_sshd_firewall | true | Boolean parameter that determines if a firewall rule should be added to allow SSH access on the given port (see the 'sshd_port' parameter). The parameter defaults to true. If you set it to false, make sure you open up the SSH port yourself, else you will be locked out! |
 | sshd_port | 22 | SSH server port that access should be granted to. Defaults to 22. |
 | purge | true | Boolean parameter that determines if all unmanaged firewall rules and chains are purged. Defaults to true. Requires puppetlabs/firewall 1.2.0+ in order,for IPv6 resources to be purged. |
 | chain_policy | DROP | Policy (drop, accept) to apply to each chain (INPUT, FORWARD, OUTPUT). Defaults to drop. The last rules in each chain are always "log then drop" so the policy has minimal effect. |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Parameters:
 |-----------|---------|-------------|
 | allow_new_outgoing_ipv4 | false | Boolean parameter that determines if the firewall should allow all new outgoing IPv4 connections. The parameter defaults to false which means that new outgoing connections will be dropped unless there is a rule that explicitly allows the traffic. |
 | allow_new_outgoing_ipv6 | false | Boolean parameter that determines if the firewall should allow all new outgoing IPv6 connections. The parameter defaults to false which means that new outgoing connections will be dropped unless there is a rule that explicitly allows the traffic. |
-| manage_sshd_firewall | true | Boolean parameter that determines if a firewall rule should be added to allow SSH access on the given port (see the 'sshd_port' parameter). The parameter defaults to true. If you set it to false, make sure you open up the SSH port yourself, else you will be locked out! |
+| manage_sshd_firewall | true | Boolean parameter that determines if a firewall rule should be added to allow SSH access on the given port (see the `sshd_port` parameter). The parameter defaults to true. If you set it to false, make sure you open up the SSH port yourself, else you will be locked out! |
 | sshd_port | 22 | SSH server port that access should be granted to. Defaults to 22. |
 | purge | true | Boolean parameter that determines if all unmanaged firewall rules and chains are purged. Defaults to true. Requires puppetlabs/firewall 1.2.0+ in order,for IPv6 resources to be purged. |
 | chain_policy | DROP | Policy (drop, accept) to apply to each chain (INPUT, FORWARD, OUTPUT). Defaults to drop. The last rules in each chain are always "log then drop" so the policy has minimal effect. |

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,12 @@
 #   new outgoing connections will be dropped unless there is a rule that
 #   explicitly allows the traffic.
 #
+# [*manage_sshd_firewall*]
+#   Boolean parameter that determines if a firewall rule should be added to allow
+#   SSH access on the given port (see the 'sshd_port' parameter). The parameter
+#   defaults to true. If you set it to false, make sure you open up the SSH port
+#   yourself, else you will be locked out!
+#
 # [*sshd_port*]
 #   SSH server port that access should be granted to. Defaults to 22.
 #
@@ -90,6 +96,7 @@
 class base_firewall(
   $allow_new_outgoing_ipv4 = false,
   $allow_new_outgoing_ipv6 = false,
+  $manage_sshd_firewall    = true,
   $sshd_port               = 22,
   $purge                   = true,
   $chain_policy            = 'drop',
@@ -101,6 +108,7 @@ class base_firewall(
 
   validate_bool($allow_new_outgoing_ipv4)
   validate_bool($allow_new_outgoing_ipv6)
+  validate_bool($manage_sshd_firewall)
 
   if !is_integer($sshd_port) or $sshd_port < 1 or $sshd_port > 65535 {
     fail('sshd_port must be an integer between [1, 65535].')
@@ -122,11 +130,12 @@ class base_firewall(
   $ignores = hiera_array('base_firewall::ignores', [])
 
   class { 'base_firewall::pre_ipv4':
-    allow_new_outgoing => $allow_new_outgoing_ipv4,
-    sshd_port          => $sshd_port,
-    chain_policy       => $chain_policy,
-    chain_purge        => $chain_purge,
-    chain_purge_ignore => $ignores,
+    allow_new_outgoing   => $allow_new_outgoing_ipv4,
+    manage_sshd_firewall => $manage_sshd_firewall,
+    sshd_port            => $sshd_port,
+    chain_policy         => $chain_policy,
+    chain_purge          => $chain_purge,
+    chain_purge_ignore   => $ignores,
   }
 
   class { 'base_firewall::post_ipv4':
@@ -134,11 +143,12 @@ class base_firewall(
   }
 
   class { 'base_firewall::pre_ipv6':
-    allow_new_outgoing => $allow_new_outgoing_ipv6,
-    sshd_port          => $sshd_port,
-    chain_policy       => $chain_policy,
-    chain_purge        => $chain_purge,
-    chain_purge_ignore => $ignores,
+    allow_new_outgoing   => $allow_new_outgoing_ipv6,
+    manage_sshd_firewall => $manage_sshd_firewall,
+    sshd_port            => $sshd_port,
+    chain_policy         => $chain_policy,
+    chain_purge          => $chain_purge,
+    chain_purge_ignore   => $ignores,
   }
 
   class { 'base_firewall::post_ipv6':

--- a/manifests/pre_ipv4.pp
+++ b/manifests/pre_ipv4.pp
@@ -13,6 +13,7 @@
 #
 class base_firewall::pre_ipv4 (
   $allow_new_outgoing,
+  $manage_sshd_firewall,
   $sshd_port,
   $chain_policy,
   $chain_purge,
@@ -106,13 +107,15 @@ class base_firewall::pre_ipv4 (
     proto  => 'icmp',
     icmp   => 'echo-request',
     action => 'accept',
-  }->
+  }
 
-  firewall { '020 allow incoming ssh':
-    dport  => $sshd_port,
-    proto  => 'tcp',
-    action => 'accept',
-  }->
+  if $manage_sshd_firewall {
+    firewall { '020 allow incoming ssh':
+      dport  => $sshd_port,
+      proto  => 'tcp',
+      action => 'accept',
+    }
+  }
 
 # -------------- Output Chain Rules ----------------
 

--- a/manifests/pre_ipv6.pp
+++ b/manifests/pre_ipv6.pp
@@ -13,6 +13,7 @@
 #
 class base_firewall::pre_ipv6 (
   $allow_new_outgoing,
+  $manage_sshd_firewall,
   $sshd_port,
   $chain_policy,
   $chain_purge,
@@ -93,13 +94,15 @@ class base_firewall::pre_ipv6 (
     proto  => 'ipv6-icmp',
     icmp   => 'echo-request',
     action => 'accept',
-  }->
+  }
 
-  firewall { '020 allow incoming ssh IPv6':
-    dport  => $sshd_port,
-    proto  => 'tcp',
-    action => 'accept',
-  }->
+  if $manage_sshd_firewall {
+    firewall { '020 allow incoming ssh IPv6':
+      dport  => $sshd_port,
+      proto  => 'tcp',
+      action => 'accept',
+    }
+  }
 
 # -------------- Output Chain Rules ----------------
 


### PR DESCRIPTION
There are cases where you would want to manage the SSH firewall rule
yourself. This is currently possible, but the rule added by this module
will still be there. This adds an option to disable the managing of this
rule by this module.