### PR TITLE
module names should use forward slash (/) instead of dash (-)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,11 +9,11 @@
   "issues_url": "https://github.com/andrewkroh/puppet-base_firewall/issues",
   "dependencies": [
     {
-      "name": "puppetlabs-firewall",
+      "name": "puppetlabs/firewall",
       "version_range": ">= 1.2.0"
     },
     {
-      "name": "puppetlabs-stdlib"
+      "name": "puppetlabs/stdlib"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Without this change, I get the following error when I use `puppet module list` (note that I **do** have the dependencies installed):
```
Warning: Missing dependency 'puppetlabs-firewall':
  'andrewkroh-base_firewall' (v1.1.1) requires 'puppetlabs-firewall' (>= 0.0.0)
Warning: Missing dependency 'puppetlabs-stdlib':
  'andrewkroh-base_firewall' (v1.1.1) requires 'puppetlabs-stdlib' (>= 0.0.0)
```

This is on Puppet 3.8 (EoL) and may not be an issue on supported version of Puppet. However, I don't see any downside to making the change.

The documentation doesn't require forward slashes, but only forward slashes are used in the examples:

- Puppet 5.3: [Specifying dependencies in modules - Module metadata and metadata.json](https://puppet.com/docs/puppet/5.3/modules_metadata.html#specifying-dependencies-in-modules).
- Puppet 4.10: [Specifying dependencies in modules - Module metadata and metadata.json](https://puppet.com/docs/puppet/4.10/modules_metadata.html#specifying-dependencies-in-modules).
- Puppet 3.8: [Specifying dependencies in modules - Publishing Modules on the Puppet Forge](https://docs.puppet.com/puppet/3.8/modules_publishing.html#dependencies-in-metadatajson)